### PR TITLE
Send Telegram chat files by URL

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -472,7 +472,7 @@ class erLhcoreClassExtensionLhctelegram
             'chat_id' => $tchat->bot->group_chat_id,
             'message_thread_id' => $tchat->tchat_id,
             'parse_mode' => 'HTML',
-            $field => Longman\TelegramBot\Request::encodeFile($file->file_path_server)
+            $field => $this->getTelegramChatFileUrl($file)
         );
 
         if ($caption !== '') {
@@ -517,6 +517,20 @@ class erLhcoreClassExtensionLhctelegram
 
         return true;
     }
+
+    private function getTelegramChatFileUrl($file)
+    {
+        $URLHash = '';
+
+        if ($file->chat_id > 0) {
+            $tsHash = time();
+            $temporaryHash = sha1($file->id . '_' . $file->hash . '_' . $tsHash . '_' . erConfigClassLhConfig::getInstance()->getSetting('site', 'secrethash'));
+            $URLHash = "/(vhash)/{$temporaryHash}/(vts)/{$tsHash}";
+        }
+
+        return erLhcoreClassSystem::getHost() . erLhcoreClassDesign::baseurldirect('file/downloadfile') . "/{$file->id}/{$file->security_hash}{$URLHash}";
+    }
+
     public function messageAdded($params)
     {
         $chat = $params['chat'];


### PR DESCRIPTION
This keeps the Telegram chat file forwarding path aligned with the existing LiveHelperChat REST API file handling.\n\nCurrent code re-uploads the local storage file with Request::encodeFile(->file_path_server), so Telegram receives the internal stored filename instead of using the file download response.\n\nThis change:\n- reuses the existing uploaded $file object;\n- builds the same temporary ile/downloadfile URL pattern used by core REST API {{file_url}};\n- keeps the existing Telegram API method selection and caption handling;\n- avoids reading file contents, temp copies, hardlinks, custom Guzzle multipart, or filename sanitizing logic in the extension.\n\nThis should let Telegram fetch the file through LHC and use the existing download response headers/file metadata instead of the internal hashed storage path.