### PR TITLE
Upload local files up to 50MB directly as multipart to Telegram topics

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -468,12 +468,27 @@ class erLhcoreClassExtensionLhctelegram
             $field = 'video';
         }
 
+        $fileSize = is_file($file->file_path_server ?? '') ? filesize($file->file_path_server) : 0;
+
         $data = array(
             'chat_id' => $tchat->bot->group_chat_id,
             'message_thread_id' => $tchat->tchat_id,
-            'parse_mode' => 'HTML',
-            $field => $this->getTelegramChatFileUrl($file)
+            'parse_mode' => 'HTML'
         );
+
+        // Telegram Bot API supports multipart file uploads up to 50 MB (52428800 bytes).
+        // URL-based download limit on Telegram servers is restricted to 20 MB.
+        // Uploading directly from server disk allows files between 20MB and 50MB (e.g. videos/recordings) to be delivered natively.
+        if ($fileSize > 0 && $fileSize <= 52428800) {
+            $fileHandle = Longman\TelegramBot\Request::encodeFile($file->file_path_server);
+            if (is_resource($fileHandle)) {
+                $data[$field] = $fileHandle;
+            } else {
+                $data[$field] = $this->getTelegramChatFileUrl($file);
+            }
+        } else {
+            $data[$field] = $this->getTelegramChatFileUrl($file);
+        }
 
         if ($caption !== '') {
             $data['caption'] = $caption;


### PR DESCRIPTION
### Summary
Telegram Bot API enforces a strict **20 MB limit** when downloading files from an external HTTP URL (`getTelegramChatFileUrl`). When a visitor or bot uploads a file between 20 MB and 50 MB (such as diagnostic videos or screen recordings), Telegram servers reject the URL download with:
`SendFile [400] Bad Request: failed to get HTTP URL content`

However, Telegram Bot API natively allows direct `multipart/form-data` file uploads up to **50 MB** (`Request::encodeFile`).

### Changes
- Check local file existence and size in `sendTelegramChatFile`.
- If the file is stored locally and its size is `<= 50 MB` (`52428800` bytes), attach the file stream via `Request::encodeFile($file->file_path_server)` so Telegram receives it directly as native media (video, photo, voice, document).
- If the file exceeds 50 MB or is remote, safely preserve the existing URL download fallback.